### PR TITLE
Renaming stateObject to ObservableObject

### DIFF
--- a/src/main/kotlin/org/orbitmvi/orbit/swift/feature/ObservableObjectProcessor.kt
+++ b/src/main/kotlin/org/orbitmvi/orbit/swift/feature/ObservableObjectProcessor.kt
@@ -24,7 +24,7 @@ import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmType
 
-class StateObjectProcessor : Processor {
+class ObservableObjectProcessor : Processor {
 
     override fun visitClass(processorContext: ProcessorContext, clazz: KmClass) {
 
@@ -67,7 +67,7 @@ class StateObjectProcessor : Processor {
             )
             val outputData = template.execute(data)
 
-            File(processorContext.outputDir, "${classSimpleName}StateObject.swift").apply {
+            File(processorContext.outputDir, "${classSimpleName}ObservableObject.swift").apply {
                 createNewFile()
                 writeText(outputData)
             }
@@ -79,6 +79,6 @@ class StateObjectProcessor : Processor {
 
     companion object {
         private val template: Template = Mustache.compiler()
-            .compile(StateObjectProcessor::class.java.classLoader.getResource("stateObject.swift.mustache")!!.readText())
+            .compile(ObservableObjectProcessor::class.java.classLoader.getResource("ObservableObject.swift.mustache")!!.readText())
     }
 }

--- a/src/main/resources/ObservableObject.swift.mustache
+++ b/src/main/resources/ObservableObject.swift.mustache
@@ -18,7 +18,7 @@ import SwiftUI
 import Combine
 import {{frameworkName}}
 
-public class {{className}}StateObject : ObservableObject {
+public class {{className}}ObservableObject : ObservableObject {
 
 {{#hasState}}    @Published public private(set) var state: {{stateType}}
 {{/hasState}}{{#hasSideEffect}}    public private(set) var sideEffect: AnyPublisher<{{sideEffectType}}, Never>
@@ -46,7 +46,7 @@ public class {{className}}StateObject : ObservableObject {
 }
 
 public extension {{className}} {
-    func asStateObject() -> {{className}}StateObject {
-        return {{className}}StateObject(wrapped: self)
+    func asObservableObject() -> {{className}}ObservableObject {
+        return {{className}}ObservableObject(wrapped: self)
     }
 }

--- a/src/main/resources/Publisher.swift.mustache
+++ b/src/main/resources/Publisher.swift.mustache
@@ -51,7 +51,7 @@ private struct FlowPublisher<T: Any>: Publisher {
 
             job = SubscribeKt.subscribe(
                     flow,
-                    onEach: { position in if let position = position as? T { _ = subscriber.receive(position) }},
+                    onEach: { value in if let value = value as? T { _ = subscriber.receive(value) }},
                     onComplete: { subscriber.receive(completion: .finished) },
                     onThrow: { error in debugPrint(error) }
             )


### PR DESCRIPTION
Renames the extension `asStateObject()` to `asObservableObject()` since the returning object conforms with the  `ObservableObject` protocol and can be used as a `@StateObject` or `@ObservedObject`:

```
@StateObject private var viewModel = ViewModels().myViewModel().asObservableObject()
@ObservedObject private var viewModel = ViewModels().myViewModel().asObservableObject()
```